### PR TITLE
Move 'read-more' inside of p tag

### DIFF
--- a/src/ReadMoreComponent.vue
+++ b/src/ReadMoreComponent.vue
@@ -1,10 +1,11 @@
 <template>
 	<div>
-		<p v-html="formattedString"></p>
-		<span v-show="text.length > maxChars">
-			<a :href="link" id="readmore" v-show="!isReadMore" v-on:click="triggerReadMore($event, true)">{{moreStr}}</a>
-			<a :href="link" id="readmore" v-show="isReadMore" v-on:click="triggerReadMore($event, false)">{{lessStr}}</a>
-		</span>
+		<p v-html="formattedString">
+			<span v-show="text.length > maxChars">
+				<a :href="link" id="readmore" v-show="!isReadMore" v-on:click="triggerReadMore($event, true)">{{moreStr}}</a>
+				<a :href="link" id="readmore" v-show="isReadMore" v-on:click="triggerReadMore($event, false)">{{lessStr}}</a>
+			</span>
+		</p>
 	</div>
 </template>
 

--- a/src/ReadMoreComponent.vue
+++ b/src/ReadMoreComponent.vue
@@ -1,6 +1,7 @@
 <template>
 	<div>
 		<p v-html="formattedString">
+      <span v-html="formattedString"> </span>
 			<span v-show="text.length > maxChars">
 				<a :href="link" id="readmore" v-show="!isReadMore" v-on:click="triggerReadMore($event, true)">{{moreStr}}</a>
 				<a :href="link" id="readmore" v-show="isReadMore" v-on:click="triggerReadMore($event, false)">{{lessStr}}</a>


### PR DESCRIPTION
Having 'read-more' right behind the text content inside the same paragraph might be the more desired layout, which is what the demo uses.