### PR TITLE
Added semi colons, shortcut for event click, data as function (long)

### DIFF
--- a/src/ReadMoreComponent.vue
+++ b/src/ReadMoreComponent.vue
@@ -2,8 +2,8 @@
 	<div>
 		<p v-html="formattedString"></p>
 		<span v-show="text.length > maxChars">
-			<a :href="link" id="readmore" v-show="!isReadMore" v-on:click="triggerReadMore($event, true)">{{moreStr}}</a>
-			<a :href="link" id="readmore" v-show="isReadMore" v-on:click="triggerReadMore($event, false)">{{lessStr}}</a>
+			<a :href="link" id="readmore" v-show="!isReadMore" @click="triggerReadMore($event, true)">{{moreStr}}</a>
+			<a :href="link" id="readmore" v-show="isReadMore" @click="triggerReadMore($event, false)">{{lessStr}}</a>
 		</span>
 	</div>
 </template>
@@ -33,9 +33,9 @@ export default {
     }
   },
 
-  data() {
+  data: function() {
     return {
-      isReadMore: false
+      isReadMore: false,
     };
   },
 

--- a/src/ReadMoreDirective.js
+++ b/src/ReadMoreDirective.js
@@ -5,7 +5,7 @@ export default {
 		
 		if(bind.value.length > bind.arg){
 
-			vn.elm.textContent = bind.value.substring(0,bind.arg)
+			vn.elm.textContent = bind.value.substring(0,bind.arg);
 			var read_more = document.createElement('a');
 	    read_more.href = '#';
 	    read_more.text = 'read more';
@@ -22,17 +22,16 @@ export default {
 			});
 
 			read_less.addEventListener("click", function(){ 
-				vn.elm.textContent = bind.value.substring(0,bind.arg)
+				vn.elm.textContent = bind.value.substring(0,bind.arg);
 				vn.elm.append(' ', read_more);
 			});
 
 		}else{
-			vn.elm.textContent = bind.value
+			vn.elm.textContent = bind.value;
 		}
 
 
 	},
 	update: function (newValue) {
-    // console.log('eyyow');
   },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-import ReadMoreComponent from './ReadMoreComponent.vue'
-import ReadMoreDirective from './ReadMoreDirective.js'
+import ReadMoreComponent from './ReadMoreComponent.vue';
+import ReadMoreDirective from './ReadMoreDirective.js';
 
 export default {
   install: function (Vue, options) {
-    Vue.component('readMore', ReadMoreComponent)
-    Vue.directive('readMore', ReadMoreDirective)
+    Vue.component('readMore', ReadMoreComponent);
+    Vue.directive('readMore', ReadMoreDirective);
   }
 }


### PR DESCRIPTION
On IE11 short data() function not work, that fixed (added long version function()) and changed v-on to @.

Sorry for short description, this is my first public pull request.
